### PR TITLE
feat(database): enforce organizationId query isolation (#11)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,12 +10,14 @@
       "license": "ISC",
       "dependencies": {
         "@prisma/client": "^6.19.2",
+        "bcrypt": "^6.0.0",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "jsonwebtoken": "^9.0.3",
         "prisma": "^6.19.2"
       },
       "devDependencies": {
+        "@types/bcrypt": "^6.0.0",
         "@types/express": "^5.0.6",
         "@types/jsonwebtoken": "^9.0.10",
         "@types/node": "^25.3.0",
@@ -176,6 +178,16 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@types/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
@@ -374,6 +386,20 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bcrypt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/bcrypt/-/bcrypt-6.0.0.tgz",
+      "integrity": "sha512-cU8v/EGSrnH+HnxV2z0J7/blxH8gq7Xh2JFT6Aroax7UohdmiJJlxApMxtKfuI7z68NvvVcmR78k2LbT6efhRg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.3.0",
+        "node-gyp-build": "^4.8.4"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -1418,11 +1444,31 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-addon-api": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.5.0.tgz",
+      "integrity": "sha512-/bRZty2mXUIFY/xU5HLvveNHlswNJej+RnxBjOMkidWfwZzgTbPG1E3K5TOxRLOR+5hX7bSofy8yf1hZevMS8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/node-fetch-native": {
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/node-fetch-native/-/node-fetch-native-1.6.7.tgz",
       "integrity": "sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==",
       "license": "MIT"
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@types/bcrypt": "^6.0.0",
     "@types/express": "^5.0.6",
     "@types/jsonwebtoken": "^9.0.10",
     "@types/node": "^25.3.0",
@@ -23,6 +24,7 @@
   },
   "dependencies": {
     "@prisma/client": "^6.19.2",
+    "bcrypt": "^6.0.0",
     "dotenv": "^17.3.1",
     "express": "^5.2.1",
     "jsonwebtoken": "^9.0.3",

--- a/backend/prisma/migrations/20260224220002_multi_tenant_email_scope/migration.sql
+++ b/backend/prisma/migrations/20260224220002_multi_tenant_email_scope/migration.sql
@@ -1,0 +1,11 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[email,organizationId]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- DropIndex
+DROP INDEX "User_email_key";
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_organizationId_key" ON "User"("email", "organizationId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,12 +20,14 @@ model Organization {
 
 model User {
   id             String   @id @default(uuid())
-  email          String   @unique
+  email          String
   password       String
   organization   Organization @relation(fields: [organizationId], references: [id])
   organizationId String
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
+
+  @@unique([email, organizationId])
 }
 
 enum Plan {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,25 +3,182 @@ import { ENV } from "./config/env"
 import { generateToken } from "./modules/auth/auth.service"
 import { verifyToken, AuthRequest } from "./modules/auth/auth.middleware"
 import { tenantValidationMiddleware, TenantRequest } from "./modules/tenant/tenant.middleware"
+import { attachTenantPrisma } from "./modules/tenant/tenant-prisma.middleware"
+import bcrypt from "bcrypt"
+import jwt from "jsonwebtoken"
+import { basePrisma } from "./lib/prisma"
+
+// IMPORTANTE: Solo usamos basePrisma para auth (login/register)
+// Para cualquier operación de negocio usamos req.prisma (tenant-scoped)
 
 const app = express()
+
 app.use(express.json())
 
-// Ruta de prueba para generar token
-app.post("/login", (req, res) => {
-  // Simulación de usuario autenticado
-  const fakeUser = {
-    userId: "user-123",
-    organizationId: "org-456",
-    email: "test@example.com"
+// ─── AUTH ────────────────────────────────────────────────────────────────────
+
+app.post("/login", async (req, res) => {
+  try {
+    const { email, password } = req.body
+
+    if (!email || !password) {
+      return res.status(400).json({ message: "Email and password are required" })
+    }
+
+    // Aquí sí usamos basePrisma porque necesitamos buscar en TODAS las orgs
+    const users = await basePrisma.user.findMany({
+      where: { email },
+      include: { organization: true }
+    })
+
+    if (users.length === 0) {
+      return res.status(401).json({ message: "Invalid credentials" })
+    }
+
+    const validUsers = []
+
+    for (const user of users) {
+      const isValid = await bcrypt.compare(password, user.password)
+      if (isValid) {
+        validUsers.push(user)
+      }
+    }
+
+    if (validUsers.length === 0) {
+      return res.status(401).json({ message: "Invalid credentials" })
+    }
+
+    if (validUsers.length === 1) {
+      const user = validUsers[0]
+
+      const token = generateToken({
+        userId: user.id,
+        organizationId: user.organizationId,
+        email: user.email
+      })
+
+      return res.json({ token })
+    }
+
+    // Usuario pertenece a múltiples organizaciones → selección requerida
+    const loginSessionToken = jwt.sign(
+      { userIds: validUsers.map(u => u.id) },
+      ENV.JWT_SECRET,
+      { expiresIn: "5m" }
+    )
+
+    return res.json({
+      requiresOrganizationSelection: true,
+      loginSessionToken,
+      organizations: validUsers.map(u => ({
+        id: u.organization.id,
+        name: u.organization.name,
+        slug: u.organization.slug
+      }))
+    })
+
+  } catch {
+    return res.status(500).json({ message: "Internal server error" })
   }
-
-  const token = generateToken(fakeUser)
-
-  return res.json({ token })
 })
 
-// Ruta protegida
+app.post("/select-organization", async (req, res) => {
+  try {
+    const { organizationId } = req.body
+    const authHeader = req.headers.authorization
+
+    if (!authHeader?.startsWith("Bearer ")) {
+      return res.status(401).json({ message: "Unauthorized" })
+    }
+
+    if (!organizationId) {
+      return res.status(400).json({ message: "organizationId is required" })
+    }
+
+    const tempToken = authHeader.split(" ")[1]
+    const decoded = jwt.verify(tempToken, ENV.JWT_SECRET) as any
+
+    // Verificamos que el usuario realmente pertenezca a esa org
+    const user = await basePrisma.user.findFirst({
+      where: {
+        id: { in: decoded.userIds },
+        organizationId
+      }
+    })
+
+    if (!user) {
+      return res.status(403).json({ message: "Invalid organization selection" })
+    }
+
+    const finalToken = generateToken({
+      userId: user.id,
+      organizationId: user.organizationId,
+      email: user.email
+    })
+
+    return res.json({ token: finalToken })
+
+  } catch {
+    return res.status(401).json({ message: "Invalid or expired session" })
+  }
+})
+
+app.post("/register", async (req, res) => {
+  try {
+    const { name, slug, email, password } = req.body
+
+    if (!name || !slug || !email || !password) {
+      return res.status(400).json({ message: "All fields are required" })
+    }
+
+    const existingOrg = await basePrisma.organization.findUnique({
+      where: { slug }
+    })
+
+    if (existingOrg) {
+      return res.status(409).json({ message: "Organization slug already exists" })
+    }
+
+    const hashedPassword = await bcrypt.hash(password, 10)
+
+    const organization = await basePrisma.organization.create({
+      data: {
+        name,
+        slug,
+        users: {
+          create: {
+            email,
+            password: hashedPassword
+          }
+        }
+      },
+      include: { users: true }
+    })
+
+    const user = organization.users[0]
+
+    const token = generateToken({
+      userId: user.id,
+      organizationId: organization.id,
+      email: user.email
+    })
+
+    return res.status(201).json({
+      token,
+      organization: {
+        id: organization.id,
+        name: organization.name,
+        slug: organization.slug
+      }
+    })
+
+  } catch {
+    return res.status(500).json({ message: "Internal server error" })
+  }
+})
+
+// ─── RUTAS PROTEGIDAS (tenant-scoped) ────────────────────────────────────────
+
 app.get("/protected", verifyToken, (req: AuthRequest, res) => {
   return res.json({
     message: "Access granted",
@@ -29,15 +186,78 @@ app.get("/protected", verifyToken, (req: AuthRequest, res) => {
   })
 })
 
-app.get(
-  "/tenant-protected",
+// POST /users — Crear usuario dentro de la org del token
+app.post(
+  "/users",
   verifyToken,
   tenantValidationMiddleware,
-  (req: TenantRequest, res) => {
-    return res.json({
-      message: "Tenant validated successfully",
-      organizationId: req.organizationId
-    })
+  attachTenantPrisma,
+  async (req: TenantRequest, res) => {
+    try {
+      const { email, password } = req.body
+
+      if (!email || !password) {
+        return res.status(400).json({ message: "Email and password are required" })
+      }
+
+      // req.prisma ya tiene el organizationId inyectado automáticamente
+      const existingUser = await req.prisma.user.findFirst({
+        where: { email }
+      })
+
+      if (existingUser) {
+        return res.status(409).json({
+          message: "User already exists in this organization"
+        })
+      }
+
+      const hashedPassword = await bcrypt.hash(password, 10)
+
+      // El organizationId se inyecta automáticamente por el tenant Prisma
+      const user = await req.prisma.user.create({
+        data: {
+          email,
+          password: hashedPassword
+        }
+      })
+
+      return res.status(201).json({
+        id: user.id,
+        email: user.email,
+        organizationId: user.organizationId
+      })
+
+    } catch {
+      return res.status(500).json({ message: "Internal server error" })
+    }
+  }
+)
+
+// GET /users — Solo devuelve usuarios de la org del token
+app.get(
+  "/users",
+  verifyToken,
+  tenantValidationMiddleware,
+  attachTenantPrisma,
+  async (req: TenantRequest, res) => {
+    try {
+      // req.prisma filtra automáticamente por organizationId del token
+      const users = await req.prisma.user.findMany({
+        select: {
+          id: true,
+          email: true,
+          organizationId: true
+        }
+      })
+
+      return res.json({
+        count: users.length,
+        users
+      })
+
+    } catch {
+      return res.status(500).json({ message: "Internal server error" })
+    }
   }
 )
 

--- a/backend/src/lib/prisma.ts
+++ b/backend/src/lib/prisma.ts
@@ -1,0 +1,73 @@
+import { PrismaClient } from "@prisma/client"
+export type TenantPrismaClient = ReturnType<typeof getTenantPrisma>
+
+const basePrisma = new PrismaClient()
+
+// Lista de modelos que son tenant-scoped
+const TENANT_MODELS = ["User"] as const
+
+export function getTenantPrisma(organizationId: string) {
+  if (!organizationId) {
+    throw new Error("organizationId is required to create a tenant Prisma client")
+  }
+
+  return basePrisma.$extends({
+    query: {
+      $allModels: {
+
+        async findMany({ model, args, query }) {
+          if (isTenantModel(model)) {
+            args.where = addTenantFilter(args.where, organizationId)
+          }
+          return query(args)
+        },
+
+        async findFirst({ model, args, query }) {
+          if (isTenantModel(model)) {
+            args.where = addTenantFilter(args.where, organizationId)
+          }
+          return query(args)
+        },
+
+        // findUnique NO se intercepta aquí porque su `where` requiere campos únicos
+        // (id o email) y agregar organizationId rompe el tipo de Prisma.
+        // Usa siempre findFirst en los controllers cuando necesites scope por tenant.
+
+        async update({ model, args, query }) {
+          if (isTenantModel(model)) {
+            args.where = addTenantFilter(args.where, organizationId) as any
+          }
+          return query(args)
+        },
+
+        async create({ model, args, query }) {
+          if (isTenantModel(model)) {
+            // Mutamos el data directamente para evitar conflicto de tipos con Prisma
+            ;(args.data as Record<string, unknown>)["organizationId"] = organizationId
+          }
+          return query(args)
+        },
+
+        async delete({ model, args, query }) {
+          if (isTenantModel(model)) {
+            args.where = addTenantFilter(args.where, organizationId) as any
+          }
+          return query(args)
+        },
+      }
+    }
+  })
+}
+
+function isTenantModel(model: string) {
+  return TENANT_MODELS.includes(model as any)
+}
+
+function addTenantFilter(where: Record<string, unknown> | undefined, organizationId: string) {
+  return {
+    ...(where ?? {}),
+    organizationId
+  }
+}
+
+export { basePrisma }

--- a/backend/src/modules/tenant/tenant-prisma.middleware.ts
+++ b/backend/src/modules/tenant/tenant-prisma.middleware.ts
@@ -1,0 +1,19 @@
+import { Response, NextFunction } from "express"
+import { TenantRequest } from "./tenant.middleware"
+import { getTenantPrisma } from "../../lib/prisma"
+
+export function attachTenantPrisma(
+  req: TenantRequest,
+  res: Response,
+  next: NextFunction
+) {
+  if (!req.organizationId) {
+    return res.status(403).json({
+      message: "Tenant context missing"
+    })
+  }
+
+  req.prisma = getTenantPrisma(req.organizationId)
+
+  next()
+}

--- a/backend/src/modules/tenant/tenant.middleware.ts
+++ b/backend/src/modules/tenant/tenant.middleware.ts
@@ -1,8 +1,9 @@
-import { Response, NextFunction } from "express"
+import { Request, Response, NextFunction } from "express"
 import { AuthRequest } from "../auth/auth.middleware"
 
 export interface TenantRequest extends AuthRequest {
   organizationId?: string
+  prisma?: any
 }
 
 export function tenantValidationMiddleware(
@@ -10,15 +11,12 @@ export function tenantValidationMiddleware(
   res: Response,
   next: NextFunction
 ) {
-  const organizationId = req.user?.organizationId
-
-  if (!organizationId) {
+  if (!req.user?.organizationId) {
     return res.status(403).json({
       message: "Tenant context missing"
     })
   }
 
-  req.organizationId = organizationId
-
+  req.organizationId = req.user.organizationId
   next()
 }

--- a/backend/src/seed-user.ts
+++ b/backend/src/seed-user.ts
@@ -1,0 +1,41 @@
+import { PrismaClient } from "@prisma/client"
+import bcrypt from "bcrypt"
+
+const prisma = new PrismaClient()
+
+async function main() {
+  // 1️⃣ Asegúrate de que exista la organización
+  const organization = await prisma.organization.findUnique({
+    where: { id: "org-456" }
+  })
+
+  if (!organization) {
+    console.log("Creating organization...")
+    await prisma.organization.create({
+      data: {
+        id: "org-456",
+        name: "Test Org",
+        slug: "test-org",
+        plan: "FREE"
+      }
+    })
+  }
+
+  // 2️⃣ Hashear password
+  const hashedPassword = await bcrypt.hash("123456", 10)
+
+  // 3️⃣ Crear usuario admin
+  await prisma.user.create({
+    data: {
+      email: "a@test.com",
+      password: hashedPassword,
+      organizationId: "org-456"
+    }
+  })
+
+  console.log("User created successfully 🚀")
+}
+
+main()
+  .catch(console.error)
+  .finally(() => prisma.$disconnect())


### PR DESCRIPTION
## Summary
Ensure all database queries are scoped by organizationId using Prisma Client Extensions.

## Changes
- Add getTenantPrisma client to auto-scope queries by organizationId
- Intercept findMany, findFirst, create, update, delete for tenant models
- Add tenantValidationMiddleware to extract organizationId from JWT
- Add attachTenantPrisma middleware to build scoped Prisma client
- Prevent cross-tenant data access on GET /users and POST /users
- Add migration for multi-tenant email scope

Closes #11